### PR TITLE
Qryptify Data Ingestor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         name: Format Python code with YAPF
         files: \.py$
         args: ["--in-place", "--recursive"]
+        additional_dependencies: [toml]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  db:
+    image: timescale/timescaledb:latest-pg16
+    container_name: qryptify_db
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: qryptify
+    ports: ["5432:5432"]
+    volumes:
+      - ./sql:/docker-entrypoint-initdb.d
+      - dbdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d qryptify"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+volumes:
+  dbdata:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import yaml
+
+from qryptify_ingestor.coordinator import run_all
+
+
+def load_cfg():
+    with open("qryptify_ingestor/config.yaml", "r") as f:
+        return yaml.safe_load(f)
+
+
+if __name__ == "__main__":
+    cfg = load_cfg()
+    asyncio.run(run_all(cfg))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "qryptify-ingestor"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "httpx>=0.27",
+  "websockets>=12.0",
+  "pyyaml>=6.0",
+  "psycopg[binary]>=3.2",
+  "tenacity>=9.0",
+  "pytz>=2024.1",
+]

--- a/qryptify_ingestor/README.md
+++ b/qryptify_ingestor/README.md
@@ -1,0 +1,133 @@
+# Qryptify Data Ingestor
+
+## Overview
+
+The **Qryptify Data Ingestor** is a service that:
+
+- Backfills historical candlestick (kline) data from Binance **Futures** API into TimescaleDB.
+- Streams **real-time** closed candlesticks via Binance WebSocket API.
+- Ensures **no duplicates** and **resumes from last saved candle** after downtime.
+
+It is the foundation for backtesting, live trading, and analytics in the Qryptify trading system.
+
+## Features
+
+- **Historical Backfill** from a configurable start date.
+- **Live WebSocket Streaming** with sub-second latency after candle close.
+- **TimescaleDB Hypertable Storage** for efficient time-series queries.
+- **Resume on Restart** using a per-symbol `sync_state`.
+- **Idempotent Inserts** via `(symbol, interval, ts)` primary key.
+
+## Architecture
+
+```text
++---------------------+        REST (backfill)        +---------------------+
+|  Ingestion Service  |------------------------------>|  Binance Futures    |
+|  (main.py)          |                                |  API (REST/WSS)     |
+|                     |<------- WebSocket (live) ---->|  /fapi/v1/klines    |
++----------+----------+                                +----------+----------+
+           |  upsert (no duplicates)                              |
+           v                                                      |
++---------------------+      hypertables/unique keys              |
+|   TimescaleDB       |<------------------------------------------+
+|  candlesticks       |
+|  sync_state         |
++---------------------+
+```
+
+## Requirements
+
+- **Python** 3.10+
+- **Docker** (for TimescaleDB)
+- Binance Futures API access (public endpoints only for this MVP)
+
+## Setup
+
+### 1. Start TimescaleDB
+
+```bash
+docker compose up -d
+```
+
+This runs TimescaleDB on port **5432** with:
+
+- DB: `qryptify`
+- User: `postgres`
+- Password: `postgres`
+
+Schema & hypertables are auto-created via `sql/001_init.sql`.
+
+### 2. Install Dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Or directly:
+
+```bash
+pip install httpx websockets pyyaml "psycopg[binary]" tenacity pytz
+```
+
+### 3. Configure
+
+Edit `qryptify_ingestor/config.yaml`:
+
+```yaml
+symbols: [BTCUSDT, ETHUSDT, BNBUSDT]
+intervals: [1m]
+rest:
+  klines_limit: 1500
+  endpoint: "https://fapi.binance.com"
+ws:
+  endpoint: "wss://fstream.binance.com/stream"
+  reconnect_initial_ms: 500
+  reconnect_max_ms: 8000
+db:
+  dsn: "postgresql://postgres:postgres@localhost:5432/qryptify"
+safety:
+  max_clock_skew_ms: 1000
+backfill:
+  start_date: "2023-01-01T00:00:00Z"
+```
+
+### 4. Run
+
+```bash
+python main.py
+```
+
+- Step 1: Backfills from `start_date` → current time.
+- Step 2: Switches to WebSocket live mode and runs until stopped.
+
+Stop with **Ctrl + C** (safe; progress is saved in DB).
+
+## Verifying Data
+
+Use the provided script:
+
+```bash
+./verify_ingestion.sh
+```
+
+This checks:
+
+1. TimescaleDB extension installed.
+2. Hypertables exist.
+3. Coverage per symbol/interval.
+4. Resume pointer (`sync_state`).
+5. Duplicate key sanity.
+6. Live data lag from now.
+
+Example:
+
+```text
+============================================================
+4) Candle coverage per (symbol, interval)
+============================================================
+BTCUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
+ETHUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
+BNBUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
+```

--- a/qryptify_ingestor/backfill_runner.py
+++ b/qryptify_ingestor/backfill_runner.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Dict, List
+
+
+def _to_dt(ms: int) -> datetime:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+
+
+def _to_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def _parse_kline(symbol: str, interval: str, arr: list) -> Dict:
+    # Binance kline schema notes (array indices)
+    # 0 open time(ms), 1 open, 2 high, 3 low, 4 close, 5 volume,
+    # 6 close time(ms), 7 quote asset vol, 8 trades, 9 taker buy base, 10 taker buy quote, 11 ignore
+    return {
+        "ts": _to_dt(arr[0]),
+        "symbol": symbol,
+        "interval": interval,
+        "open": arr[1],
+        "high": arr[2],
+        "low": arr[3],
+        "close": arr[4],
+        "volume": arr[5],
+        "close_time": _to_dt(arr[6]),
+        "quote_asset_volume": arr[7],
+        "number_of_trades": int(arr[8]),
+        "taker_buy_base": arr[9],
+        "taker_buy_quote": arr[10],
+    }
+
+
+async def run_backfill(cfg, repo, client):
+    symbols = cfg["symbols"]
+    intervals = cfg["intervals"]
+    limit = cfg["rest"]["klines_limit"]
+    min_start = datetime.fromisoformat(cfg["backfill"]["start_date"].replace(
+        "Z", "+00:00"))
+
+    for sym in symbols:
+        for itv in intervals:
+            last = repo.get_last_closed_ts(sym, itv)
+            start_dt = max_dt(min_start,
+                              (last + step_of(itv)) if last else min_start)
+            start_ms = _to_ms(start_dt)
+
+            while True:
+                batch = await client.klines(sym,
+                                            itv,
+                                            start_ms=start_ms,
+                                            limit=limit)
+                if not batch:
+                    break
+                rows = [_parse_kline(sym, itv, arr) for arr in batch]
+                inserted = repo.upsert_klines(rows)
+                # advance by last close
+                last_close_ms = batch[-1][6]
+                repo.set_last_closed_ts(sym, itv, _to_dt(last_close_ms))
+
+                # stop when we are very close to "now" (let live take over)
+                if (datetime.now(timezone.utc) -
+                        _to_dt(last_close_ms)) < step_of(itv):
+                    break
+                start_ms = last_close_ms + 1
+
+
+def max_dt(a: datetime, b: datetime) -> datetime:
+    return a if a >= b else b
+
+
+def step_of(interval: str):
+    table = {
+        "1m": timedelta(minutes=1),
+        "3m": timedelta(minutes=3),
+        "5m": timedelta(minutes=5),
+        "15m": timedelta(minutes=15),
+        "1h": timedelta(hours=1),
+    }
+    return table[interval]

--- a/qryptify_ingestor/binance_client.py
+++ b/qryptify_ingestor/binance_client.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+import websockets
+
+KLINE_PATH = "/fapi/v1/klines"
+TIME_PATH = "/fapi/v1/time"
+
+
+class BinanceClient:
+
+    def __init__(self, rest_base: str, ws_base: str, timeout_s: float = 30.0):
+        self._rest_base = rest_base.rstrip("/")
+        self._ws_base = ws_base.rstrip("/")
+        self._timeout_s = timeout_s
+
+    async def server_time_ms(self) -> int:
+        async with httpx.AsyncClient(timeout=self._timeout_s) as cli:
+            r = await cli.get(self._rest_base + TIME_PATH)
+            r.raise_for_status()
+            return int(r.json()["serverTime"])
+
+    async def klines(
+        self,
+        symbol: str,
+        interval: str,
+        start_ms: Optional[int] = None,
+        end_ms: Optional[int] = None,
+        limit: int = 1500,
+    ) -> List[list]:
+        params = {"symbol": symbol, "interval": interval, "limit": limit}
+        if start_ms is not None: params["startTime"] = start_ms
+        if end_ms is not None: params["endTime"] = end_ms
+        async with httpx.AsyncClient(timeout=self._timeout_s) as cli:
+            r = await cli.get(self._rest_base + KLINE_PATH, params=params)
+            r.raise_for_status()
+            return r.json()
+
+    async def ws_kline_stream(self, symbols: list[str], interval: str):
+        """
+        Yields closed kline payloads as dicts:
+        {
+          "s": "BTCUSDT",
+          "k": { "t": open_time, "T": close_time, "i": "1m", "x": true, ... }
+        }
+        """
+        streams = "/".join(f"{s.lower()}@kline_{interval}" for s in symbols)
+        url = f"{self._ws_base}?streams={streams}"
+        async for ws in _ws_reconnect(url):
+            try:
+                async for msg in ws:
+                    data = json.loads(msg)
+                    k = data.get("data", {}).get("k")
+                    if k and k.get("x") is True:
+                        yield {"symbol": data["data"]["s"], "k": k}
+            except websockets.ConnectionClosed:
+                continue
+
+
+async def _ws_reconnect(url: str, initial_ms: int = 500, max_ms: int = 8000):
+    backoff = initial_ms
+    while True:
+        try:
+            async with websockets.connect(url, open_timeout=10) as ws:
+                yield ws
+                backoff = initial_ms  # reset after a clean session
+        except Exception:
+            await asyncio.sleep(backoff / 1000)
+            backoff = min(backoff * 2, max_ms)
+            continue

--- a/qryptify_ingestor/config.yaml
+++ b/qryptify_ingestor/config.yaml
@@ -1,0 +1,15 @@
+symbols: [BTCUSDT, ETHUSDT, BNBUSDT]
+intervals: [1h]
+rest:
+  klines_limit: 1500
+  endpoint: "https://fapi.binance.com"
+ws:
+  endpoint: "wss://fstream.binance.com/stream"
+  reconnect_initial_ms: 500
+  reconnect_max_ms: 8000
+db:
+  dsn: "postgresql://postgres:postgres@localhost:5432/qryptify"
+safety:
+  max_clock_skew_ms: 1000
+backfill:
+  start_date: "2023-01-01T00:00:00Z" # min boundary

--- a/qryptify_ingestor/coordinator.py
+++ b/qryptify_ingestor/coordinator.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+
+from tenacity import retry
+from tenacity import stop_after_attempt
+from tenacity import wait_exponential
+
+from .backfill_runner import run_backfill
+from .binance_client import BinanceClient
+from .live_runner import run_live
+from .timescale_repo import TimescaleRepo
+
+
+@retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=8))
+async def run_all(cfg):
+    client = BinanceClient(cfg["rest"]["endpoint"], cfg["ws"]["endpoint"])
+    repo = TimescaleRepo(cfg["db"]["dsn"])
+    repo.connect()
+    try:
+        # Optional: check server clock skew
+        _ = await client.server_time_ms()
+        # Backfill first
+        await run_backfill(cfg, repo, client)
+        # Then live streaming until killed
+        await run_live(cfg, repo, client)
+    finally:
+        repo.close()

--- a/qryptify_ingestor/live_runner.py
+++ b/qryptify_ingestor/live_runner.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+
+
+def _to_dt(ms: int):  # shared tiny helper
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+
+
+def _row_from_k(symbol: str, k: dict, interval: str) -> dict:
+    return {
+        "ts": _to_dt(k["t"]),
+        "symbol": symbol,
+        "interval": interval,
+        "open": k["o"],
+        "high": k["h"],
+        "low": k["l"],
+        "close": k["c"],
+        "volume": k["v"],
+        "close_time": _to_dt(k["T"]),
+        "quote_asset_volume": k["q"],
+        "number_of_trades": int(k["n"]),
+        "taker_buy_base": k["V"],
+        "taker_buy_quote": k["Q"],
+    }
+
+
+async def run_live(cfg, repo, client):
+    symbols = cfg["symbols"]
+    intervals = cfg["intervals"]
+    assert len(intervals) == 1, "MVP: single interval for WS"
+    itv = intervals[0]
+
+    async for msg in client.ws_kline_stream(symbols, itv):
+        k = msg["k"]
+        sym = msg["symbol"]
+        if k.get("x") is True:  # candle closed
+            row = _row_from_k(sym, k, itv)
+            repo.upsert_klines([row])
+            repo.set_last_closed_ts(sym, itv, row["close_time"])

--- a/qryptify_ingestor/timescale_repo.py
+++ b/qryptify_ingestor/timescale_repo.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+from typing import Iterable, Optional
+
+import psycopg
+from psycopg.rows import dict_row
+
+
+class TimescaleRepo:
+
+    def __init__(self, dsn: str):
+        self._dsn = dsn
+
+    def connect(self):
+        self._conn = psycopg.connect(self._dsn, autocommit=False)
+        self._conn.execute("SET TIME ZONE 'UTC'")
+        self._cur = self._conn.cursor(row_factory=dict_row)
+
+    def close(self):
+        self._cur.close()
+        self._conn.close()
+
+    def upsert_klines(self, rows: Iterable[dict]) -> int:
+        sql = """
+        INSERT INTO candlesticks (
+          ts, symbol, interval, open, high, low, close, volume, close_time,
+          quote_asset_volume, number_of_trades, taker_buy_base, taker_buy_quote
+        ) VALUES (
+          %(ts)s, %(symbol)s, %(interval)s, %(open)s, %(high)s, %(low)s, %(close)s, %(volume)s, %(close_time)s,
+          %(quote_asset_volume)s, %(number_of_trades)s, %(taker_buy_base)s, %(taker_buy_quote)s
+        )
+        ON CONFLICT (symbol, interval, ts) DO NOTHING
+        """
+        self._cur.executemany(sql, list(rows))
+        inserted = self._cur.rowcount
+        self._conn.commit()
+        return inserted
+
+    def get_last_closed_ts(self, symbol: str,
+                           interval: str) -> Optional[datetime]:
+        self._cur.execute(
+            "SELECT last_closed_ts FROM sync_state WHERE symbol=%s AND interval=%s",
+            (symbol, interval),
+        )
+        row = self._cur.fetchone()
+        return row["last_closed_ts"] if row and row["last_closed_ts"] else None
+
+    def set_last_closed_ts(self, symbol: str, interval: str,
+                           ts: datetime) -> None:
+        self._cur.execute(
+            """
+            INSERT INTO sync_state(symbol, interval, last_closed_ts)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (symbol, interval) DO UPDATE
+              SET last_closed_ts = EXCLUDED.last_closed_ts
+            """,
+            (symbol, interval, ts),
+        )
+        self._conn.commit()

--- a/sql/001_init.sql
+++ b/sql/001_init.sql
@@ -1,0 +1,43 @@
+-- Enable TimescaleDB
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- Optional: symbols registry (handy for joins later)
+CREATE TABLE IF NOT EXISTS symbols (
+  symbol TEXT PRIMARY KEY
+);
+
+INSERT INTO symbols(symbol) VALUES
+('BTCUSDT'), ('ETHUSDT'), ('BNBUSDT')
+ON CONFLICT DO NOTHING;
+
+-- Candlesticks hypertable
+CREATE TABLE IF NOT EXISTS candlesticks (
+  ts TIMESTAMPTZ NOT NULL,
+  symbol TEXT NOT NULL,
+  interval TEXT NOT NULL,
+  open NUMERIC NOT NULL,
+  high NUMERIC NOT NULL,
+  low  NUMERIC NOT NULL,
+  close NUMERIC NOT NULL,
+  volume NUMERIC NOT NULL,
+  close_time TIMESTAMPTZ NOT NULL,
+  quote_asset_volume NUMERIC NOT NULL,
+  number_of_trades INT NOT NULL,
+  taker_buy_base NUMERIC NOT NULL,
+  taker_buy_quote NUMERIC NOT NULL,
+  PRIMARY KEY (symbol, interval, ts)
+);
+
+SELECT create_hypertable('candlesticks', 'ts', if_not_exists => TRUE);
+
+-- Sync state for resume
+CREATE TABLE IF NOT EXISTS sync_state (
+  symbol TEXT NOT NULL,
+  interval TEXT NOT NULL,
+  last_closed_ts TIMESTAMPTZ,
+  PRIMARY KEY (symbol, interval)
+);
+
+-- Helpful index for time filters per symbol/interval
+CREATE INDEX IF NOT EXISTS idx_candles_sym_int_ts
+ON candlesticks(symbol, interval, ts DESC);

--- a/verify_ingestion.sh
+++ b/verify_ingestion.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Config (override via env) ---
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-postgres}"
+PGDATABASE="${PGDATABASE:-qryptify}"
+PGPASSWORD="${PGPASSWORD:-postgres}"   # export PGPASSWORD=... to avoid prompts
+
+PSQL="psql -h $PGHOST -p $PGPORT -U $PGUSER -d $PGDATABASE -v ON_ERROR_STOP=1 -X -q -A -F $'\t'"
+
+bar() { printf "\n============================================================\n%s\n============================================================\n" "$1"; }
+
+bar "1) Extensions installed"
+$PSQL -c "SELECT extname FROM pg_extension ORDER BY 1;"
+
+bar "2) Timescale hypertables"
+$PSQL -c "SELECT hypertable_schema, hypertable_name, num_chunks, compression_enabled
+          FROM timescaledb_information.hypertables
+          ORDER BY 1,2;"
+
+bar "3) Tables present"
+$PSQL -c "\dt"
+
+bar "4) Candle coverage per (symbol, interval)"
+$PSQL -c "
+SELECT symbol, interval,
+       MIN(ts)  AS first_open,
+       MAX(ts)  AS last_open,
+       COUNT(*) AS rows
+FROM candlesticks
+GROUP BY 1,2
+ORDER BY 1,2;"
+
+bar "5) Resume pointers (sync_state)"
+$PSQL -c "SELECT symbol, interval, last_closed_ts
+          FROM sync_state
+          ORDER BY 1,2;"
+
+bar "6) Duplicate check (PK uniqueness sanity)"
+$PSQL -c "
+WITH t AS (SELECT symbol, interval, ts FROM candlesticks)
+SELECT
+  (SELECT COUNT(*) FROM t)                                      AS total_rows,
+  (SELECT COUNT(*) FROM (SELECT DISTINCT symbol,interval,ts FROM t) d) AS distinct_rows;"
+
+bar "7) Live lag (how far from now)"
+$PSQL -c "
+WITH latest AS (
+  SELECT symbol, MAX(ts) AS last_open
+  FROM candlesticks
+  WHERE interval='1m'
+  GROUP BY symbol
+)
+SELECT symbol,
+       last_open,
+       now() AT TIME ZONE 'utc' AS now_utc,
+       (now() AT TIME ZONE 'utc') - last_open AS lag
+FROM latest
+ORDER BY 1;"
+
+bar "Done "


### PR DESCRIPTION
# Qryptify Data Ingestor

## Overview

The **Qryptify Data Ingestor** is a service that:

- Backfills historical candlestick (kline) data from Binance **Futures** API into TimescaleDB.
- Streams **real-time** closed candlesticks via Binance WebSocket API.
- Ensures **no duplicates** and **resumes from last saved candle** after downtime.

It is the foundation for backtesting, live trading, and analytics in the Qryptify trading system.

## Features

- **Historical Backfill** from a configurable start date.
- **Live WebSocket Streaming** with sub-second latency after candle close.
- **TimescaleDB Hypertable Storage** for efficient time-series queries.
- **Resume on Restart** using a per-symbol `sync_state`.
- **Idempotent Inserts** via `(symbol, interval, ts)` primary key.

## Architecture

```text
+---------------------+        REST (backfill)        +---------------------+
|  Ingestion Service  |------------------------------>|  Binance Futures    |
|  (main.py)          |                                |  API (REST/WSS)     |
|                     |<------- WebSocket (live) ---->|  /fapi/v1/klines    |
+----------+----------+                                +----------+----------+
           |  upsert (no duplicates)                              |
           v                                                      |
+---------------------+      hypertables/unique keys              |
|   TimescaleDB       |<------------------------------------------+
|  candlesticks       |
|  sync_state         |
+---------------------+
```

## Requirements

- **Python** 3.10+
- **Docker** (for TimescaleDB)
- Binance Futures API access (public endpoints only for this MVP)

## Setup

### 1. Start TimescaleDB

```bash
docker compose up -d
```

This runs TimescaleDB on port **5432** with:

- DB: `qryptify`
- User: `postgres`
- Password: `postgres`

Schema & hypertables are auto-created via `sql/001_init.sql`.

### 2. Install Dependencies

```bash
python -m venv .venv
source .venv/bin/activate
pip install -e .
```

Or directly:

```bash
pip install httpx websockets pyyaml "psycopg[binary]" tenacity pytz
```

### 3. Configure

Edit `qryptify_ingestor/config.yaml`:

```yaml
symbols: [BTCUSDT, ETHUSDT, BNBUSDT]
intervals: [1m]
rest:
  klines_limit: 1500
  endpoint: "https://fapi.binance.com"
ws:
  endpoint: "wss://fstream.binance.com/stream"
  reconnect_initial_ms: 500
  reconnect_max_ms: 8000
db:
  dsn: "postgresql://postgres:postgres@localhost:5432/qryptify"
safety:
  max_clock_skew_ms: 1000
backfill:
  start_date: "2023-01-01T00:00:00Z"
```

### 4. Run

```bash
python main.py
```

- Step 1: Backfills from `start_date` → current time.
- Step 2: Switches to WebSocket live mode and runs until stopped.

Stop with **Ctrl + C** (safe; progress is saved in DB).

## Verifying Data

Use the provided script:

```bash
./verify_ingestion.sh
```

This checks:

1. TimescaleDB extension installed.
2. Hypertables exist.
3. Coverage per symbol/interval.
4. Resume pointer (`sync_state`).
5. Duplicate key sanity.
6. Live data lag from now.

Example:

```text
============================================================
4) Candle coverage per (symbol, interval)
============================================================
BTCUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
ETHUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
BNBUSDT  1m   2023-01-01 00:00:00+00   2025-08-10 09:50:00+00   1234567
```
